### PR TITLE
Allow adding more table indexing configuration for Pinot tables.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,8 @@ jobs:
       - gradle:
           args: copyAllReports --output-dir=/tmp/test-reports
           when: always
-      - codecov/upload
+      - codecov/upload:
+          flags: unit
       - store_test_results:
           path: /tmp/test-reports
       - store_artifacts:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@ import org.hypertrace.gradle.publishing.HypertracePublishExtension
 import org.hypertrace.gradle.publishing.License
 
 plugins {
-  id("org.hypertrace.repository-plugin") version "0.1.2"
-  id("org.hypertrace.ci-utils-plugin") version "0.1.1"
-  id("org.hypertrace.publish-plugin") version "0.3.0" apply false
-  id("org.hypertrace.jacoco-report-plugin") version "0.1.0" apply false
+  id("org.hypertrace.repository-plugin") version "0.2.3"
+  id("org.hypertrace.ci-utils-plugin") version "0.1.4"
+  id("org.hypertrace.publish-plugin") version "0.3.3" apply false
+  id("org.hypertrace.jacoco-report-plugin") version "0.1.3" apply false
 }
 
 subprojects {

--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -6,15 +6,10 @@ plugins {
   id("org.hypertrace.jacoco-report-plugin")
 }
 
-repositories {
-  // Need this to fetch confluent's kafka-clients dependency
-  maven("http://packages.confluent.io/maven")
-}
-
 sourceSets {
   test {
     java {
-      srcDirs("src/test/java", "build/generated-test-avro-java")
+      srcDirs("build/generated-test-avro-java")
     }
   }
 }
@@ -27,76 +22,32 @@ dependencies {
   implementation("org.hypertrace.core.eventstore:event-store:0.1.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.13")
   constraints {
-    implementation("com.google.guava:guava:29.0-jre") {
-      because("Deserialization of Untrusted Data [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@20.0\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > com.google.guava:guava@20.0")
-    }
     implementation("io.netty:netty-all:4.1.50.Final") {
-      because("HTTP Request Smuggling [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-559515] in io.netty:netty-all@4.1.28.Final\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-core@0.3.0 > io.netty:netty-all@4.1.28.Final")
-    }
-    implementation("com.jcraft:jsch:0.1.55") {
-      because("Directory Traversal [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMJCRAFT-30302] in com.jcraft:jsch@0.1.42\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@2.7.0 > com.jcraft:jsch@0.1.42")
-    }
-    implementation("commons-codec:commons-codec:1.14") {
-      because("Information Exposure [Low Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518] in commons-codec:commons-codec@1.10\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@2.7.0 > commons-codec:commons-codec@1.10")
+      because("HTTP Request Smuggling [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-559515] in io.netty:netty-all@4.1.28.Final")
     }
     implementation("commons-collections:commons-collections:3.2.2") {
-      because("Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078] in commons-collections:commons-collections@3.2.1\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@2.7.0 > commons-collections:commons-collections@3.2.1")
-    }
-    implementation("org.apache.hadoop:hadoop-common:3.2.1") {
-      because("Arbitrary File Write via Archive Extraction (Zip Slip) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHADOOP-174573] in org.apache.hadoop:hadoop-common@2.7.0\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@2.7.0")
+      because("Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078] in commons-collections:commons-collections@3.2.1")
     }
     implementation("org.apache.thrift:libthrift:0.13.0") {
-      because("Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-474610] in org.apache.thrift:libthrift@0.12.0\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.apache.thrift:libthrift@0.12.0 and 7 other path(s)")
+      because("Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-474610] in org.apache.thrift:libthrift@0.12.0")
     }
     implementation("org.webjars:swagger-ui:3.27.0") {
-      because("Reverse Tabnabbing [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-449821] in org.webjars:swagger-ui@2.2.2\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.webjars:swagger-ui@2.2.2")
+      because("Reverse Tabnabbing [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-449821] in org.webjars:swagger-ui@2.2.2")
     }
     implementation("org.yaml:snakeyaml:1.26") {
-      because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGYAML-537645] in org.yaml:snakeyaml@1.23\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.yaml:snakeyaml@1.23")
-    }
-    implementation("commons-beanutils:commons-beanutils:1.9.4") {
-      because("Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111] in commons-beanutils:commons-beanutils@1.9.3\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@3.2.1 > commons-beanutils:commons-beanutils@1.9.3")
-    }
-    implementation("com.nimbusds:nimbus-jose-jwt:8.19") {
-      because("Improper Check for Unusual or Exceptional Conditions [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMNIMBUSDS-536068] in com.nimbusds:nimbus-jose-jwt@4.41.1\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@3.2.1 > org.apache.hadoop:hadoop-auth@3.2.1 > com.nimbusds:nimbus-jose-jwt@4.41.1")
-    }
-    implementation("org.eclipse.jetty:jetty-http:9.4.30.v20200611") {
-      because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174011] in org.eclipse.jetty:jetty-http@9.3.24.v20180605\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@3.2.1 > org.eclipse.jetty:jetty-server@9.3.24.v20180605 > org.eclipse.jetty:jetty-http@9.3.24.v20180605")
-    }
-    implementation("org.eclipse.jetty:jetty-server:9.4.30.v20200611") {
-      because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174560] in org.eclipse.jetty:jetty-server@9.3.24.v20180605\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.hadoop:hadoop-common@3.2.1 > org.eclipse.jetty:jetty-server@9.3.24.v20180605")
+      because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGYAML-537645] in org.yaml:snakeyaml@1.23")
     }
     implementation("org.apache.zookeeper:zookeeper:3.6.1") {
-      because("Access Control Bypass [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEZOOKEEPER-174781] in org.apache.zookeeper:zookeeper@3.4.13\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.apache.zookeeper:zookeeper@3.4.13")
+      because("Access Control Bypass [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEZOOKEEPER-174781] in org.apache.zookeeper:zookeeper@3.4.13")
     }
     implementation("io.netty:netty:3.10.6.Final") {
-      because("Information Exposure [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-30430] in io.netty:netty@3.9.6.Final\n" +
-          "   introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > io.netty:netty@3.9.6.Final")
+      because("Information Exposure [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-30430] in io.netty:netty@3.9.6.Final")
     }
-
     implementation("org.glassfish.jersey.core:jersey-server:2.31") {
-      because("XML Entity Expansion [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972] in org.glassfish.jersey.media:jersey-media-jaxb@2.28\n" +
-              "    introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.glassfish.jersey.core:jersey-server@2.28 > org.glassfish.jersey.media:jersey-media-jaxb@2.28 and 1 other path(s)\n")
+      because("XML Entity Expansion [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972] in org.glassfish.jersey.media:jersey-media-jaxb@2.28")
     }
-    implementation("io.grpc:grpc-core@1.31.0") {
-      version {
-        because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IOGRPC-571957] in io.grpc:grpc-core@1.30.0")
-        require("1.31.0")
-      }
+    implementation("io.grpc:grpc-core:1.31.0") {
+      because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IOGRPC-571957] in io.grpc:grpc-core@1.30.0")
     }
   }
 

--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.test {
 
 dependencies {
   implementation("org.hypertrace.core.eventstore:event-store:0.1.1")
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.9")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.13")
   constraints {
     implementation("com.google.guava:guava:29.0-jre") {
       because("Deserialization of Untrusted Data [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@20.0\n" +
@@ -91,6 +91,9 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-server:2.31") {
       because("XML Entity Expansion [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972] in org.glassfish.jersey.media:jersey-media-jaxb@2.28\n" +
               "    introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.glassfish.jersey.core:jersey-server@2.28 > org.glassfish.jersey.media:jersey-media-jaxb@2.28 and 1 other path(s)\n")
+    }
+    implementation("io.grpc:grpc-netty-shaded@1.31.0") {
+      because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IOGRPC-571957] in io.grpc:grpc-core@1.30.0")
     }
   }
 

--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
 
   implementation("org.apache.avro:avro:1.9.2")
   implementation("org.apache.kafka:kafka-clients:5.5.0-ccs")
-  implementation("org.apache.pinot:pinot-tools:0.3.0") {
+  implementation("org.apache.pinot:pinot-tools:0.5.0") {
     // We use newer version of servlet-api brought by jetty so we exclude the older
     // version here.
     exclude("javax.servlet", "javax.servlet-api")

--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -92,8 +92,11 @@ dependencies {
       because("XML Entity Expansion [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972] in org.glassfish.jersey.media:jersey-media-jaxb@2.28\n" +
               "    introduced by org.apache.pinot:pinot-tools@0.3.0 > org.apache.pinot:pinot-common@0.3.0 > org.glassfish.jersey.core:jersey-server@2.28 > org.glassfish.jersey.media:jersey-media-jaxb@2.28 and 1 other path(s)\n")
     }
-    implementation("io.grpc:grpc-netty-shaded@1.31.0") {
-      because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IOGRPC-571957] in io.grpc:grpc-core@1.30.0")
+    implementation("io.grpc:grpc-core@1.31.0") {
+      version {
+        because("Information Exposure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IOGRPC-571957] in io.grpc:grpc-core@1.30.0")
+        require("1.31.0")
+      }
     }
   }
 

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/ViewCreationSpec.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/ViewCreationSpec.java
@@ -59,23 +59,34 @@ public class ViewCreationSpec {
     private String controllerHost;
     private String controllerPort;
 
-    private TimeUnit timeUnit;
-    private String timeColumn;
-    private List<String> dimensionColumns;
-    private List<String> metricColumns;
-    private List<String> invertedIndexColumns;
-    private Map<String, Object> columnsMaxLength;
-
     // Table configs;
     private String tableName;
-    private Map<String, Object> streamConfigs;
     private String loadMode;
+
+    private List<String> dimensionColumns;
+    private List<String> metricColumns;
+
+    // Table index configs
+    private List<String> invertedIndexColumns;
+    private List<String> noDictionaryColumns;
+    private List<String> bloomFilterColumns;
+    private List<String> rangeIndexColumns;
+    private Map<String, Object> columnsMaxLength;
+
+    // Stream configs
+    private Map<String, Object> streamConfigs;
+
+    // Segments config
     private int numReplicas;
+    private TimeUnit timeUnit;
+    private String timeColumn;
     private String retentionTimeValue;
     private String retentionTimeUnit;
+    private String segmentAssignmentStrategy;
+
+    // Tenants config
     private String brokerTenant;
     private String serverTenant;
-    private String segmentAssignmentStrategy;
 
     public PinotTableSpec() {
 
@@ -217,6 +228,29 @@ public class ViewCreationSpec {
       this.segmentAssignmentStrategy = segmentAssignmentStrategy;
     }
 
+    public List<String> getNoDictionaryColumns() {
+      return noDictionaryColumns;
+    }
+
+    public void setNoDictionaryColumns(List<String> noDictionaryColumns) {
+      this.noDictionaryColumns = noDictionaryColumns;
+    }
+
+    public List<String> getBloomFilterColumns() {
+      return bloomFilterColumns;
+    }
+
+    public void setBloomFilterColumns(List<String> bloomFilterColumns) {
+      this.bloomFilterColumns = bloomFilterColumns;
+    }
+
+    public List<String> getRangeIndexColumns() {
+      return rangeIndexColumns;
+    }
+
+    public void setRangeIndexColumns(List<String> rangeIndexColumns) {
+      this.rangeIndexColumns = rangeIndexColumns;
+    }
   }
 
   public static class KafkaSpec {

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotMultiTableCreationTool.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotMultiTableCreationTool.java
@@ -12,7 +12,7 @@ public class PinotMultiTableCreationTool implements TableCreationTool {
   private static final String CLUSTER_NAME = "cluster.name";
   private static final String POD_NAME = "pod.name";
   private static final String CONTAINER_NAME = "container.name";
-  private List<String> viewsToCreate;
+  private final List<String> viewsToCreate;
 
   public PinotMultiTableCreationTool(List<String> viewsToCreate) {
     this.viewsToCreate = viewsToCreate;
@@ -20,14 +20,13 @@ public class PinotMultiTableCreationTool implements TableCreationTool {
 
   @Override
   public void create() {
-    viewsToCreate.stream()
-        .forEach(
-            viewName -> {
-              ViewCreationSpec viewCreationSpec = parseViewCreationSpec(viewName);
-              PinotTableCreationTool tableCreationTool =
-                  new PinotTableCreationTool(viewCreationSpec);
-              tableCreationTool.create();
-            });
+    viewsToCreate.forEach(
+        viewName -> {
+          ViewCreationSpec viewCreationSpec = parseViewCreationSpec(viewName);
+          PinotTableCreationTool tableCreationTool =
+              new PinotTableCreationTool(viewCreationSpec);
+          tableCreationTool.create();
+        });
   }
 
   private ViewCreationSpec parseViewCreationSpec(String viewName) {

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableCreationTool.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableCreationTool.java
@@ -1,6 +1,6 @@
 package org.hypertrace.core.viewcreator.pinot;
 
-import org.apache.pinot.common.config.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.hypertrace.core.viewcreator.TableCreationTool;
 import org.hypertrace.core.viewcreator.ViewCreationSpec;
@@ -25,7 +25,7 @@ public class PinotTableCreationTool implements TableCreationTool {
     if (!uploadPinotSchema) {
       throw new RuntimeException("Failed to upload Pinot schema.");
     }
-    final TableConfig tableConfig = PinotUtils.createPinotTable(viewCreationSpec);
+    final TableConfig tableConfig = PinotUtils.createPinotTableConfig(viewCreationSpec);
     final boolean createPinotTable =
         PinotUtils.sendPinotTableCreationRequest(viewCreationSpec, tableConfig);
     if (!createPinotTable) {

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec-without-schema.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec-without-schema.conf
@@ -1,26 +1,31 @@
-view.name = myView
-view.output.schema.url = "host:port/myView"
-view.output.schema.class = org.hypertrace.core.viewcreator.test.api.TestView
+view = {
+  name = myView
+  output.schema.url = "host:port/myView"
+  output.schema.class = org.hypertrace.core.viewcreator.test.api.TestView
+}
 
-pinot.controllerHost = localhost
-pinot.controllerPort = 9000
-pinot.timeColumn = start_time_millis
-pinot.timeUnit = MILLISECONDS
-pinot.dimensionColumns = [duration_millis, end_time_millis, services, transaction_name, trace_id]
-pinot.columnsMaxLength={transaction_name: 12}
-pinot.metricColumns = [num_spans, num_services]
-pinot.invertedIndexColumns = [tags__KEYS, tags__VALUES]
-pinot.tableName = myView1
-pinot.loadMode = MMAP
-pinot.numReplicas = 1
-pinot.retentionTimeValue = 3
-pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
-pinot.serverTenant = defaultServer
-pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
+pinot = {
+  controllerHost = localhost
+  controllerPort = 9000
+  timeColumn = start_time_millis
+  timeUnit = MILLISECONDS
+  dimensionColumns = [duration_millis, end_time_millis, services, transaction_name, trace_id]
+  columnsMaxLength={transaction_name: 12}
+  metricColumns = [num_spans, num_services]
+  invertedIndexColumns = [tags__KEYS, tags__VALUES]
+  bloomFilterColumns = []
+  noDictionaryColumns = []
+  rangeIndexColumns = []
+  tableName = myView1
+  loadMode = MMAP
+  numReplicas = 1
+  retentionTimeValue = 3
+  retentionTimeUnit = DAYS
+  brokerTenant = defaultBroker
+  serverTenant = defaultServer
+  segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 
-pinot.streamConfigs =
-  {
+  streamConfigs = {
     streamType: kafka,
     stream.kafka.consumer.type: simple,
     stream.kafka.topic.name: raw-trace-view-events,
@@ -32,3 +37,4 @@ pinot.streamConfigs =
     realtime.segment.flush.threshold.size: 50000,
     stream.kafka.consumer.prop.auto.offset.reset: smallest
   }
+}

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
@@ -1,43 +1,51 @@
 tool.class = org.hypertrace.core.viewcreator.pinot.PinotTableCreationTool
 service.name = "sample-view"
-view.name = myView
-view.output.schema.class = org.hypertrace.core.viewcreator.test.api.TestView
-view.output.schema.url = "host:port/myView"
+view = {
+  name = myView
+  output.schema.class = org.hypertrace.core.viewcreator.test.api.TestView
+  output.schema.url = "host:port/myView"
+}
 
-kafka.brokerAddress = "localhost:9092"
-kafka.topicName = test-view-events
-kafka.partitions = 8
-kafka.replicationFactor = 3
+kafka = {
+  brokerAddress = "localhost:9092"
+  topicName = test-view-events
+  partitions = 8
+  replicationFactor = 3
+}
 
-pinot.controllerHost = localhost
-pinot.controllerPort = 9000
-pinot.timeColumn = creation_time_millis
-pinot.timeUnit = MILLISECONDS
-pinot.dimensionColumns = [name, creation_time_millis, id_sha, friends, properties__KEYS, properties__VALUES]
-pinot.columnsMaxLength = {id_sha: 64}
-pinot.metricColumns = [time_taken_millis]
-pinot.invertedIndexColumns = [friends, properties__KEYS, properties__VALUES]
-pinot.tableName = myView1
-pinot.loadMode = MMAP
-pinot.numReplicas = 1
-pinot.retentionTimeValue = 3
-pinot.retentionTimeUnit = DAYS
-pinot.brokerTenant = defaultBroker
-pinot.serverTenant = defaultServer
-pinot.segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
+pinot = {
+  controllerHost = localhost
+  controllerPort = 9000
+  timeColumn = creation_time_millis
+  timeUnit = MILLISECONDS
+  dimensionColumns = [name, creation_time_millis, id_sha, friends, properties__KEYS, properties__VALUES]
+  columnsMaxLength = {id_sha: 64}
+  metricColumns = [time_taken_millis]
+  invertedIndexColumns = [friends, properties__KEYS, properties__VALUES]
+  noDictionaryColumns = [properties__VALUES]
+  bloomFilterColumns = [id_sha]
+  rangeIndexColumns = [creation_time_millis]
+  tableName = myView1
+  loadMode = MMAP
+  numReplicas = 1
+  retentionTimeValue = 3
+  retentionTimeUnit = DAYS
+  brokerTenant = defaultBroker
+  serverTenant = defaultServer
+  segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
 
-pinot.streamConfigs =
-{
-  streamType: kafka,
-  stream.kafka.consumer.type: LowLevel,
-  stream.kafka.topic.name: test-view-events,
-  stream.kafka.consumer.factory.class.name: "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-  stream.kafka.decoder.class.name: "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
-  stream.kafka.decoder.prop.schema.registry.rest.url: "http://localhost:8081",
-  stream.kafka.hlc.zk.connect.string: "localhost:2181",
-  stream.kafka.zk.broker.url: "localhost:2181",
-  stream.kafka.broker.list: "localhost:9092",
-  realtime.segment.flush.threshold.time: 3600000,
-  realtime.segment.flush.threshold.size: 500000,
-  stream.kafka.consumer.prop.auto.offset.reset: largest
+  streamConfigs = {
+    streamType: kafka,
+    stream.kafka.consumer.type: LowLevel,
+    stream.kafka.topic.name: test-view-events,
+    stream.kafka.consumer.factory.class.name: "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+    stream.kafka.decoder.class.name: "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+    stream.kafka.decoder.prop.schema.registry.rest.url: "http://localhost:8081",
+    stream.kafka.hlc.zk.connect.string: "localhost:2181",
+    stream.kafka.zk.broker.url: "localhost:2181",
+    stream.kafka.broker.list: "localhost:9092",
+    realtime.segment.flush.threshold.time: 3600000,
+    realtime.segment.flush.threshold.size: 500000,
+    stream.kafka.consumer.prop.auto.offset.reset: largest
+  }
 }

--- a/view-generator-framework/build.gradle.kts
+++ b/view-generator-framework/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.test {
 }
 
 dependencies {
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.9")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.13")
   implementation("org.hypertrace.core.flinkutils:flink-utils:0.1.6")
 
   implementation("org.apache.avro:avro:1.9.2")


### PR DESCRIPTION
Currently, we only allow the inverted indices to be added to Pinot table but
we need to be able to add other indexes like bloom filters, range indexes
to optimize the performance of Pinot queries. This PR let's that config to
be tunable easily.

I'm also rethinking if we should have this indirection in Pinot table config
or should we directly provide the JSON that's needed but that's for future PRs.

Also upgraded the pinot-tools to 0.5.0 version in this PR.