### PR TITLE
chore: upgrading kstream framework version to 0.1.21

### DIFF
--- a/view-generator-framework/build.gradle.kts
+++ b/view-generator-framework/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
 
   implementation("com.typesafe:config:1.4.1")
 
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.20")
-  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.20")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-framework:0.1.21")
+  implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.21")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.8.0")


### PR DESCRIPTION
upgrading kafka-stream-framework version to 0.1.21 to use kstream version `6.0.1`