### PR TITLE
ci: update codeowners and skip ut publish on fork

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 * @hypertrace/trace-pipeline-owners
 
 # GH action
-.github/ @aaron-steinfeld @jbahire @kotharironak @buchi-busireddy
+.github/ @hypertrace/ci-owners

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,7 +54,7 @@ jobs:
      
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
-        if: always()
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ./**/build/test-results/**/*.xml


### PR DESCRIPTION
## Description
Skip unit test result publish on fork (as it requires a GH token) and update codeowners
