### PR TITLE
chore: upgrade log4j again

### DIFF
--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.typesafe:config:1.4.1")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/view-generator-framework/build.gradle.kts
+++ b/view-generator-framework/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 
   implementation("com.typesafe:config:1.4.1")
 
@@ -43,7 +43,7 @@ dependencies {
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.8.0")
-  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 
   constraints {
   }


### PR DESCRIPTION
## Description
Not known to be vulnerable in current config, but upgrading log4j due to https://nvd.nist.gov/vuln/detail/CVE-2021-45046 out of abundance of caution.