### PR TITLE
feat: adds multiple inputs for view-gen for combing streams

### DIFF
--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -69,10 +69,10 @@ dependencies {
     implementation("org.apache.commons:commons-compress:1.21") {
       because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316640] in org.apache.commons:commons-compress@1.20")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
-      because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+      because("Denial of Service (DoS) [High Severity]" +
+          "[https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/view-generator-framework/build.gradle.kts
+++ b/view-generator-framework/build.gradle.kts
@@ -37,10 +37,10 @@ dependencies {
     implementation("org.apache.commons:commons-compress:1.21") {
       because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316640] in org.apache.commons:commons-compress@1.20")
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
-      because("Denial of Service (DoS) " +
-          "[Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] " +
-          "in com.fasterxml.jackson.core:jackson-databind@2.12.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.1") {
+      because("Denial of Service (DoS) [High Severity]" +
+          "[https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] " +
+          "in com.fasterxml.jackson.core:jackson-databind@2.13.1")
     }
   }
 

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/MultiViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/MultiViewGeneratorLauncher.java
@@ -1,6 +1,9 @@
 package org.hypertrace.core.viewgenerator.service;
 
-import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.*;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.INPUT_TOPICS_CONFIG_KEY;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.MULTI_VIEW_GEN_JOB_CONFIG;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.OUTPUT_TOPIC_CONFIG_KEY;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.VIEW_GENERATORS_CONFIG;
 
 import com.typesafe.config.Config;
 import java.util.HashMap;
@@ -61,7 +64,7 @@ public class MultiViewGeneratorLauncher extends KafkaStreamsApp {
     Set<String> inputTopics = new HashSet<>();
     for (String viewGen : viewGenNames) {
       Config viewGenConfig = viewGenConfigs.get(viewGen);
-      inputTopics.add(viewGenConfig.getString(INPUT_TOPIC_CONFIG_KEY));
+      inputTopics.addAll(viewGenConfig.getStringList(INPUT_TOPICS_CONFIG_KEY));
     }
     return inputTopics.stream().collect(Collectors.toList());
   }

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGenerationProcessTransformer.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGenerationProcessTransformer.java
@@ -14,7 +14,7 @@ import org.apache.kafka.streams.processor.To;
 import org.hypertrace.core.viewgenerator.JavaCodeBasedViewGenerator;
 
 public class ViewGenerationProcessTransformer<IN extends SpecificRecord, OUT extends GenericRecord>
-    implements Transformer<String, IN, List<KeyValue<String, OUT>>> {
+    implements Transformer<Object, IN, List<KeyValue<Object, OUT>>> {
 
   private final String viewGenName;
 
@@ -48,8 +48,8 @@ public class ViewGenerationProcessTransformer<IN extends SpecificRecord, OUT ext
   }
 
   @Override
-  public List<KeyValue<String, OUT>> transform(String key, IN value) {
-    List<KeyValue<String, OUT>> outputKVPairs = new ArrayList<>();
+  public List<KeyValue<Object, OUT>> transform(Object key, IN value) {
+    List<KeyValue<Object, OUT>> outputKVPairs = new ArrayList<>();
     List<OUT> output = viewGenerator.process(value);
     if (output != null) {
       for (OUT out : output) {

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGenerationProcessTransformer.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGenerationProcessTransformer.java
@@ -14,7 +14,7 @@ import org.apache.kafka.streams.processor.To;
 import org.hypertrace.core.viewgenerator.JavaCodeBasedViewGenerator;
 
 public class ViewGenerationProcessTransformer<IN extends SpecificRecord, OUT extends GenericRecord>
-    implements Transformer<Object, IN, List<KeyValue<Object, OUT>>> {
+    implements Transformer<String, IN, List<KeyValue<String, OUT>>> {
 
   private final String viewGenName;
 
@@ -48,8 +48,8 @@ public class ViewGenerationProcessTransformer<IN extends SpecificRecord, OUT ext
   }
 
   @Override
-  public List<KeyValue<Object, OUT>> transform(Object key, IN value) {
-    List<KeyValue<Object, OUT>> outputKVPairs = new ArrayList<>();
+  public List<KeyValue<String, OUT>> transform(String key, IN value) {
+    List<KeyValue<String, OUT>> outputKVPairs = new ArrayList<>();
     List<OUT> output = viewGenerator.process(value);
     if (output != null) {
       for (OUT out : output) {

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorConstants.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorConstants.java
@@ -2,7 +2,7 @@ package org.hypertrace.core.viewgenerator.service;
 
 public class ViewGeneratorConstants {
 
-  public static final String INPUT_TOPIC_CONFIG_KEY = "input.topic";
+  public static final String INPUT_TOPICS_CONFIG_KEY = "input.topics";
   public static final String OUTPUT_TOPIC_CONFIG_KEY = "output.topic";
   public static final String VIEW_GENERATOR_CLASS_CONFIG_KEY = "view.generator.class";
   public static final String VIEW_GENERATORS_CONFIG = "view.generators";

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
@@ -44,7 +44,7 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
     List<String> inputTopics = jobConfig.getStringList(INPUT_TOPICS_CONFIG_KEY);
     String outputTopic = jobConfig.getString(OUTPUT_TOPIC_CONFIG_KEY);
 
-    KStream<Object, Object> mergeStream = null;
+    KStream<Object, Object> mergedStream = null;
 
     for (String topic : inputTopics) {
       KStream<Object, Object> inputStream = (KStream<Object, Object>) inputStreams.get(topic);
@@ -54,10 +54,10 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
         inputStreams.put(topic, inputStream);
       }
 
-      if (mergeStream == null) {
-        mergeStream = inputStream;
+      if (mergedStream == null) {
+        mergedStream = inputStream;
       } else {
-        mergeStream = mergeStream.merge(inputStream);
+        mergedStream = mergedStream.merge(inputStream);
       }
     }
 
@@ -75,7 +75,7 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
       }
     }
 
-    mergeStream
+    mergedStream
         .flatTransform(() -> new ViewGenerationProcessTransformer(getJobConfigKey()))
         .to(outputTopic, Produced.with(null, producerValueSerde));
     return streamsBuilder;

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
@@ -8,6 +8,7 @@ import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
@@ -44,13 +45,13 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
     List<String> inputTopics = jobConfig.getStringList(INPUT_TOPICS_CONFIG_KEY);
     String outputTopic = jobConfig.getString(OUTPUT_TOPIC_CONFIG_KEY);
 
-    KStream<Object, Object> mergedStream = null;
+    KStream<String, Object> mergedStream = null;
 
     for (String topic : inputTopics) {
-      KStream<Object, Object> inputStream = (KStream<Object, Object>) inputStreams.get(topic);
+      KStream<String, Object> inputStream = (KStream<String, Object>) inputStreams.get(topic);
 
       if (inputStream == null) {
-        inputStream = streamsBuilder.stream(topic, Consumed.with(null, null));
+        inputStream = streamsBuilder.stream(topic, Consumed.with(Serdes.String(), null));
         inputStreams.put(topic, inputStream);
       }
 
@@ -77,7 +78,7 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
 
     mergedStream
         .flatTransform(() -> new ViewGenerationProcessTransformer(getJobConfigKey()))
-        .to(outputTopic, Produced.with(null, producerValueSerde));
+        .to(outputTopic, Produced.with(Serdes.String(), producerValueSerde));
     return streamsBuilder;
   }
 

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
@@ -8,7 +8,6 @@ import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
@@ -45,13 +44,13 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
     List<String> inputTopics = jobConfig.getStringList(INPUT_TOPICS_CONFIG_KEY);
     String outputTopic = jobConfig.getString(OUTPUT_TOPIC_CONFIG_KEY);
 
-    KStream<String, Object> mergeStream = null;
+    KStream<Object, Object> mergeStream = null;
 
     for (String topic : inputTopics) {
-      KStream<String, Object> inputStream = (KStream<String, Object>) inputStreams.get(topic);
+      KStream<Object, Object> inputStream = (KStream<Object, Object>) inputStreams.get(topic);
 
       if (inputStream == null) {
-        inputStream = streamsBuilder.stream(topic, Consumed.with(Serdes.String(), null));
+        inputStream = streamsBuilder.stream(topic, Consumed.with(null, null));
         inputStreams.put(topic, inputStream);
       }
 
@@ -78,7 +77,7 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
 
     mergeStream
         .flatTransform(() -> new ViewGenerationProcessTransformer(getJobConfigKey()))
-        .to(outputTopic, Produced.with(Serdes.String(), producerValueSerde));
+        .to(outputTopic, Produced.with(null, producerValueSerde));
     return streamsBuilder;
   }
 

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
@@ -47,12 +47,11 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
 
     KStream<String, Object> mergeStream = null;
 
-    for(String topic : inputTopics) {
+    for (String topic : inputTopics) {
       KStream<String, Object> inputStream = (KStream<String, Object>) inputStreams.get(topic);
 
       if (inputStream == null) {
-        inputStream = streamsBuilder
-            .stream(topic, Consumed.with(Serdes.String(), null));
+        inputStream = streamsBuilder.stream(topic, Consumed.with(Serdes.String(), null));
         inputStreams.put(topic, inputStream);
       }
 

--- a/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
+++ b/view-generator-framework/src/main/java/org/hypertrace/core/viewgenerator/service/ViewGeneratorLauncher.java
@@ -1,7 +1,7 @@
 package org.hypertrace.core.viewgenerator.service;
 
 import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.DEFAULT_VIEW_GEN_JOB_CONFIG_KEY;
-import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.INPUT_TOPIC_CONFIG_KEY;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.INPUT_TOPICS_CONFIG_KEY;
 import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.OUTPUT_TOPIC_CONFIG_KEY;
 
 import com.typesafe.config.Config;
@@ -42,7 +42,7 @@ public class ViewGeneratorLauncher extends KafkaStreamsApp {
 
     Config jobConfig = getJobConfig(properties);
 
-    List<String> inputTopics = jobConfig.getStringList(INPUT_TOPIC_CONFIG_KEY);
+    List<String> inputTopics = jobConfig.getStringList(INPUT_TOPICS_CONFIG_KEY);
     String outputTopic = jobConfig.getString(OUTPUT_TOPIC_CONFIG_KEY);
 
     KStream<String, Object> mergeStream = null;

--- a/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
+++ b/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
@@ -29,4 +29,9 @@ protocol TestAvroSchemas {
 
     string span_kind;
   }
+
+  record KeyType {
+    string tenant_id;
+    string span_id;
+  }
 }

--- a/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
+++ b/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
@@ -29,9 +29,4 @@ protocol TestAvroSchemas {
 
     string span_kind;
   }
-
-  record KeyType {
-    string tenant_id;
-    string span_id;
-  }
 }

--- a/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
+++ b/view-generator-framework/src/test/avro/TestAvroSchemas.avdl
@@ -19,4 +19,14 @@ protocol TestAvroSchemas {
 
     string span_kind;
   }
+
+  record RawServiceType {
+    string span_id;
+
+    long start_time_millis = 0;
+
+    long end_time_millis = 0;
+
+    string span_kind;
+  }
 }

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.viewgenerator;
 
 import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.MULTI_VIEW_GEN_JOB_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestInputTopic;
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.TopologyTestDriver;
 import org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 import org.hypertrace.core.viewgenerator.service.MultiViewGeneratorLauncher;
+import org.hypertrace.core.viewgenerator.test.api.KeyType;
 import org.hypertrace.core.viewgenerator.test.api.RawServiceType;
 import org.hypertrace.core.viewgenerator.test.api.SpanTypeOne;
 import org.hypertrace.core.viewgenerator.test.api.SpanTypeTwo;
@@ -31,9 +32,9 @@ import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 public class MultiViewGeneratorLauncherTest {
   private MultiViewGeneratorLauncher underTest;
-  private List<TestInputTopic<byte[], SpanTypeOne>> inputTopics = new ArrayList<>();
-  private TestOutputTopic<byte[], SpanTypeTwo> spanTypeTwoOutputTopic;
-  private TestOutputTopic<byte[], RawServiceType> rawServiceTypeOutputTopic;
+  private List<TestInputTopic<KeyType, SpanTypeOne>> inputTopics = new ArrayList<>();
+  private TestOutputTopic<KeyType, SpanTypeTwo> spanTypeTwoOutputTopic;
+  private TestOutputTopic<KeyType, RawServiceType> rawServiceTypeOutputTopic;
 
   @BeforeEach
   @SetEnvironmentVariable(key = "SERVICE_NAME", value = "test-multi-view-generator")
@@ -58,6 +59,9 @@ public class MultiViewGeneratorLauncherTest {
 
     TopologyTestDriver td = new TopologyTestDriver(streamsBuilder.build(), props);
 
+    Serde<KeyType> keyTypeAvroSerde = new AvroSerde<>();
+    keyTypeAvroSerde.configure(Map.of(), false);
+
     Serde<SpanTypeOne> spanTypeOneSerde = new AvroSerde<>();
     spanTypeOneSerde.configure(Map.of(), false);
 
@@ -70,22 +74,21 @@ public class MultiViewGeneratorLauncherTest {
     // pick up from each view-gen config
     List<String> topics = List.of("test-input-topic1", "test-input-topic2");
     for (String topic : topics) {
-      TestInputTopic<byte[], SpanTypeOne> inputTopic =
-          td.createInputTopic(
-              topic, Serdes.ByteArray().serializer(), spanTypeOneSerde.serializer());
+      TestInputTopic<KeyType, SpanTypeOne> inputTopic =
+          td.createInputTopic(topic, keyTypeAvroSerde.serializer(), spanTypeOneSerde.serializer());
       inputTopics.add(inputTopic);
     }
 
     spanTypeTwoOutputTopic =
         td.createOutputTopic(
             "test-span-type-two-output-topic",
-            Serdes.ByteArray().deserializer(),
+            keyTypeAvroSerde.deserializer(),
             spanTypeTwoSerde.deserializer());
 
     rawServiceTypeOutputTopic =
         td.createOutputTopic(
             "test-raw-service-type-output-topic",
-            Serdes.ByteArray().deserializer(),
+            keyTypeAvroSerde.deserializer(),
             rawServiceTypeSerde.deserializer());
   }
 
@@ -116,14 +119,14 @@ public class MultiViewGeneratorLauncherTest {
     // test-view-gen-raw-service consume only from one input topic, so it should
     // get only one piped output.
     inputTopics.get(0).pipeInput(null, span);
-    KeyValue<byte[], SpanTypeTwo> spanTypeTwoKeyValue = spanTypeTwoOutputTopic.readKeyValue();
+    KeyValue<KeyType, SpanTypeTwo> spanTypeTwoKeyValue = spanTypeTwoOutputTopic.readKeyValue();
     assertNull(spanTypeTwoKeyValue.key, "null key expected");
     assertEquals("span-id", spanTypeTwoKeyValue.value.getSpanId());
     assertEquals("span-kind", spanTypeTwoKeyValue.value.getSpanKind());
     assertEquals(spanStartTime, spanTypeTwoKeyValue.value.getStartTimeMillis());
     assertEquals(spanEndTime, spanTypeTwoKeyValue.value.getEndTimeMillis());
 
-    KeyValue<byte[], RawServiceType> rawServiceTypeKeyValue =
+    KeyValue<KeyType, RawServiceType> rawServiceTypeKeyValue =
         rawServiceTypeOutputTopic.readKeyValue();
     assertNull(rawServiceTypeKeyValue.key, "null key expected");
     assertEquals("span-id", rawServiceTypeKeyValue.value.getSpanId());
@@ -141,5 +144,26 @@ public class MultiViewGeneratorLauncherTest {
     assertEquals(spanEndTime, spanTypeTwoKeyValue.value.getEndTimeMillis());
 
     assertTrue(rawServiceTypeOutputTopic.isEmpty());
+
+    // test by sending non-null key
+    inputTopics
+        .get(0)
+        .pipeInput(KeyType.newBuilder().setTenantId("t1").setSpanId("t1-1234").build(), span);
+    inputTopics
+        .get(1)
+        .pipeInput(KeyType.newBuilder().setTenantId("t2").setSpanId("t2-1234").build(), span1);
+
+    // two records for span-event, one record for raw-service type
+    spanTypeTwoKeyValue = spanTypeTwoOutputTopic.readKeyValue();
+    assertNotNull(spanTypeTwoKeyValue.key, "non null key expected");
+    assertTrue(List.of("t1", "t2").contains(spanTypeTwoKeyValue.key.getTenantId()));
+
+    spanTypeTwoKeyValue = spanTypeTwoOutputTopic.readKeyValue();
+    assertNotNull(spanTypeTwoKeyValue.key, "non null key expected");
+    assertTrue(List.of("t1", "t2").contains(spanTypeTwoKeyValue.key.getTenantId()));
+
+    rawServiceTypeKeyValue = rawServiceTypeOutputTopic.readKeyValue();
+    assertNotNull(rawServiceTypeKeyValue.key, "non null key expected");
+    assertEquals("t1", rawServiceTypeKeyValue.key.getTenantId());
   }
 }

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
@@ -67,7 +67,7 @@ public class MultiViewGeneratorLauncherTest {
     rawServiceTypeSerde.configure(Map.of(), false);
 
     // pick up from each view-gen config
-    List<String> topics = List.of("test-input-topic1", "test-input-topic12");
+    List<String> topics = List.of("test-input-topic1", "test-input-topic2");
     for (String topic : topics) {
       TestInputTopic<byte[], SpanTypeOne> inputTopic =
           td.createInputTopic(

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/MultiViewGeneratorLauncherTest.java
@@ -1,0 +1,132 @@
+package org.hypertrace.core.viewgenerator;
+
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.MULTI_VIEW_GEN_JOB_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde;
+import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
+import org.hypertrace.core.viewgenerator.service.MultiViewGeneratorLauncher;
+import org.hypertrace.core.viewgenerator.test.api.RawServiceType;
+import org.hypertrace.core.viewgenerator.test.api.SpanTypeOne;
+import org.hypertrace.core.viewgenerator.test.api.SpanTypeTwo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+public class MultiViewGeneratorLauncherTest {
+  private MultiViewGeneratorLauncher underTest;
+  private List<TestInputTopic<byte[], SpanTypeOne>> inputTopics = new ArrayList<>();
+  private TestOutputTopic<byte[], SpanTypeTwo> spanTypeTwoOutputTopic;
+  private TestOutputTopic<byte[], RawServiceType> rawServiceTypeOutputTopic;
+
+  @BeforeEach
+  @SetEnvironmentVariable(key = "SERVICE_NAME", value = "test-multi-view-generator")
+  public void setUp() {
+    underTest = new MultiViewGeneratorLauncher(ConfigClientFactory.getClient());
+    Config config =
+        ConfigFactory.parseURL(
+            getClass()
+                .getClassLoader()
+                .getResource("configs/test-multi-view-generator/application.conf"));
+
+    Map<String, Object> mergedProps = new HashMap<>();
+    underTest.getBaseStreamsConfig().forEach(mergedProps::put);
+    underTest.getStreamsConfig(config).forEach(mergedProps::put);
+    mergedProps.put(MULTI_VIEW_GEN_JOB_CONFIG, config);
+
+    StreamsBuilder streamsBuilder =
+        underTest.buildTopology(mergedProps, new StreamsBuilder(), new HashMap<>());
+
+    Properties props = new Properties();
+    mergedProps.forEach(props::put);
+
+    TopologyTestDriver td = new TopologyTestDriver(streamsBuilder.build(), props);
+
+    Serde<SpanTypeOne> spanTypeOneSerde = new AvroSerde<>();
+    spanTypeOneSerde.configure(Map.of(), false);
+
+    Serde<SpanTypeTwo> spanTypeTwoSerde = new AvroSerde<>();
+    spanTypeTwoSerde.configure(Map.of(), false);
+
+    Serde<RawServiceType> rawServiceTypeSerde = new AvroSerde<>();
+    rawServiceTypeSerde.configure(Map.of(), false);
+
+    // pick up from each view-gen config
+    List<String> topics = List.of("test-input-topic1", "test-input-topic12");
+    for (String topic : topics) {
+      TestInputTopic<byte[], SpanTypeOne> inputTopic =
+          td.createInputTopic(
+              topic, Serdes.ByteArray().serializer(), spanTypeOneSerde.serializer());
+      inputTopics.add(inputTopic);
+    }
+
+    spanTypeTwoOutputTopic =
+        td.createOutputTopic(
+            "test-span-type-two-output-topic",
+            Serdes.ByteArray().deserializer(),
+            spanTypeTwoSerde.deserializer());
+
+    rawServiceTypeOutputTopic =
+        td.createOutputTopic(
+            "test-raw-service-type-output-topic",
+            Serdes.ByteArray().deserializer(),
+            rawServiceTypeSerde.deserializer());
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "SERVICE_NAME", value = "test-multi-view-generator")
+  public void testMultiViewGeneratorTopologyWithMultipleInputStreams() {
+    long spanStartTime = System.currentTimeMillis();
+    long spanEndTime = spanStartTime + 1000;
+
+    SpanTypeOne span =
+        SpanTypeOne.newBuilder()
+            .setSpanId("span-id")
+            .setSpanKind("span-kind")
+            .setStartTimeMillis(spanStartTime)
+            .setEndTimeMillis(spanEndTime)
+            .build();
+
+    SpanTypeOne span1 =
+        SpanTypeOne.newBuilder()
+            .setSpanId("span-id-1")
+            .setSpanKind("span-kind")
+            .setStartTimeMillis(spanStartTime)
+            .setEndTimeMillis(spanEndTime)
+            .build();
+
+    Serde<SpanTypeOne> spanTypeOneSerde = new AvroSerde<>();
+    spanTypeOneSerde.configure(Map.of(), false);
+
+    inputTopics.get(0).pipeInput(null, span);
+    KeyValue<byte[], SpanTypeTwo> kv = spanTypeTwoOutputTopic.readKeyValue();
+    assertNull(kv.key, "null key expected");
+    assertEquals("span-id", kv.value.getSpanId());
+    assertEquals("span-kind", kv.value.getSpanKind());
+    assertEquals(spanStartTime, kv.value.getStartTimeMillis());
+    assertEquals(spanEndTime, kv.value.getEndTimeMillis());
+
+    inputTopics.get(1).pipeInput(null, span1);
+    kv = spanTypeTwoOutputTopic.readKeyValue();
+    assertNull(kv.key, "null key expected");
+    assertEquals("span-id-1", kv.value.getSpanId());
+    assertEquals("span-kind", kv.value.getSpanKind());
+    assertEquals(spanStartTime, kv.value.getStartTimeMillis());
+    assertEquals(spanEndTime, kv.value.getEndTimeMillis());
+  }
+}

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/TestRawServiceViewGenerator.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/TestRawServiceViewGenerator.java
@@ -1,0 +1,35 @@
+package org.hypertrace.core.viewgenerator;
+
+import java.util.List;
+import org.apache.avro.Schema;
+import org.hypertrace.core.viewgenerator.test.api.RawServiceType;
+import org.hypertrace.core.viewgenerator.test.api.SpanTypeOne;
+
+public class TestRawServiceViewGenerator
+    implements JavaCodeBasedViewGenerator<SpanTypeOne, RawServiceType> {
+  @Override
+  public List<RawServiceType> process(SpanTypeOne span) {
+    return List.of(
+        RawServiceType.newBuilder()
+            .setSpanId(span.getSpanId())
+            .setStartTimeMillis(span.getStartTimeMillis())
+            .setEndTimeMillis(span.getEndTimeMillis())
+            .setSpanKind(span.getSpanKind())
+            .build());
+  }
+
+  @Override
+  public String getViewName() {
+    return RawServiceType.class.getName();
+  }
+
+  @Override
+  public Schema getSchema() {
+    return RawServiceType.getClassSchema();
+  }
+
+  @Override
+  public Class<RawServiceType> getViewClass() {
+    return RawServiceType.class;
+  }
+}

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/TestSpanEventViewGenerator.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/TestSpanEventViewGenerator.java
@@ -1,0 +1,35 @@
+package org.hypertrace.core.viewgenerator;
+
+import java.util.List;
+import org.apache.avro.Schema;
+import org.hypertrace.core.viewgenerator.test.api.SpanTypeOne;
+import org.hypertrace.core.viewgenerator.test.api.SpanTypeTwo;
+
+public class TestSpanEventViewGenerator
+    implements JavaCodeBasedViewGenerator<SpanTypeOne, SpanTypeTwo> {
+  @Override
+  public List<SpanTypeTwo> process(SpanTypeOne span) {
+    return List.of(
+        SpanTypeTwo.newBuilder()
+            .setSpanId(span.getSpanId())
+            .setStartTimeMillis(span.getStartTimeMillis())
+            .setEndTimeMillis(span.getEndTimeMillis())
+            .setSpanKind(span.getSpanKind())
+            .build());
+  }
+
+  @Override
+  public String getViewName() {
+    return SpanTypeTwo.class.getName();
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SpanTypeTwo.getClassSchema();
+  }
+
+  @Override
+  public Class<SpanTypeTwo> getViewClass() {
+    return SpanTypeTwo.class;
+  }
+}

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
@@ -1,7 +1,10 @@
 package org.hypertrace.core.viewgenerator;
 
-import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.DEFAULT_VIEW_GEN_JOB_CONFIG_KEY;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.INPUT_TOPICS_CONFIG_KEY;
+import static org.hypertrace.core.viewgenerator.service.ViewGeneratorConstants.OUTPUT_TOPIC_CONFIG_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -12,7 +15,11 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.*;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 import org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher;
@@ -57,7 +64,7 @@ public class ViewGeneratorLauncherTest {
     Serde<SpanTypeTwo> spanTypeTwoSerde = new AvroSerde<>();
     spanTypeTwoSerde.configure(Map.of(), false);
 
-    List<String> topics = config.getStringList(INPUT_TOPIC_CONFIG_KEY);
+    List<String> topics = config.getStringList(INPUT_TOPICS_CONFIG_KEY);
     for (String topic : topics) {
       TestInputTopic<byte[], SpanTypeOne> inputTopic =
           td.createInputTopic(

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
@@ -58,12 +58,10 @@ public class ViewGeneratorLauncherTest {
     spanTypeTwoSerde.configure(Map.of(), false);
 
     List<String> topics = config.getStringList(INPUT_TOPIC_CONFIG_KEY);
-    for(String topic : topics) {
+    for (String topic : topics) {
       TestInputTopic<byte[], SpanTypeOne> inputTopic =
           td.createInputTopic(
-              topic,
-              Serdes.ByteArray().serializer(),
-              spanTypeOneSerde.serializer());
+              topic, Serdes.ByteArray().serializer(), spanTypeOneSerde.serializer());
       inputTopics.add(inputTopic);
     }
     outputTopic =
@@ -141,6 +139,5 @@ public class ViewGeneratorLauncherTest {
     assertEquals("span-kind", kv.value.getSpanKind());
     assertEquals(spanStartTime, kv.value.getStartTimeMillis());
     assertEquals(spanEndTime, kv.value.getEndTimeMillis());
-
   }
 }

--- a/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
+++ b/view-generator-framework/src/test/java/org/hypertrace/core/viewgenerator/ViewGeneratorLauncherTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serde;
@@ -23,7 +25,7 @@ import org.junitpioneer.jupiter.SetEnvironmentVariable;
 public class ViewGeneratorLauncherTest {
   private static final String SERVICE_NAME = "servicename";
   private ViewGeneratorLauncher underTest;
-  TestInputTopic<byte[], SpanTypeOne> inputTopic;
+  List<TestInputTopic<byte[], SpanTypeOne>> inputTopics = new ArrayList<>();
   TestOutputTopic<byte[], SpanTypeTwo> outputTopic;
 
   @BeforeEach
@@ -55,11 +57,15 @@ public class ViewGeneratorLauncherTest {
     Serde<SpanTypeTwo> spanTypeTwoSerde = new AvroSerde<>();
     spanTypeTwoSerde.configure(Map.of(), false);
 
-    inputTopic =
-        td.createInputTopic(
-            config.getString(INPUT_TOPIC_CONFIG_KEY),
-            Serdes.ByteArray().serializer(),
-            spanTypeOneSerde.serializer());
+    List<String> topics = config.getStringList(INPUT_TOPIC_CONFIG_KEY);
+    for(String topic : topics) {
+      TestInputTopic<byte[], SpanTypeOne> inputTopic =
+          td.createInputTopic(
+              topic,
+              Serdes.ByteArray().serializer(),
+              spanTypeOneSerde.serializer());
+      inputTopics.add(inputTopic);
+    }
     outputTopic =
         td.createOutputTopic(
             config.getString(OUTPUT_TOPIC_CONFIG_KEY),
@@ -84,7 +90,7 @@ public class ViewGeneratorLauncherTest {
     Serde<SpanTypeOne> spanTypeOneSerde = new AvroSerde<>();
     spanTypeOneSerde.configure(Map.of(), false);
 
-    inputTopic.pipeInput(null, span);
+    inputTopics.get(0).pipeInput(null, span);
 
     KeyValue<byte[], SpanTypeTwo> kv = outputTopic.readKeyValue();
     assertNull(kv.key, "null key expected");
@@ -92,5 +98,49 @@ public class ViewGeneratorLauncherTest {
     assertEquals("span-kind", kv.value.getSpanKind());
     assertEquals(spanStartTime, kv.value.getStartTimeMillis());
     assertEquals(spanEndTime, kv.value.getEndTimeMillis());
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "SERVICE_NAME", value = "test-view-generator")
+  public void testViewGeneratorTopologyWithMultipleInputStreams() {
+    long spanStartTime = System.currentTimeMillis();
+    long spanEndTime = spanStartTime + 1000;
+
+    SpanTypeOne span =
+        SpanTypeOne.newBuilder()
+            .setSpanId("span-id")
+            .setSpanKind("span-kind")
+            .setStartTimeMillis(spanStartTime)
+            .setEndTimeMillis(spanEndTime)
+            .build();
+
+    SpanTypeOne span1 =
+        SpanTypeOne.newBuilder()
+            .setSpanId("span-id-1")
+            .setSpanKind("span-kind")
+            .setStartTimeMillis(spanStartTime)
+            .setEndTimeMillis(spanEndTime)
+            .build();
+
+    Serde<SpanTypeOne> spanTypeOneSerde = new AvroSerde<>();
+    spanTypeOneSerde.configure(Map.of(), false);
+
+    inputTopics.get(0).pipeInput(null, span);
+
+    KeyValue<byte[], SpanTypeTwo> kv = outputTopic.readKeyValue();
+    assertNull(kv.key, "null key expected");
+    assertEquals("span-id", kv.value.getSpanId());
+    assertEquals("span-kind", kv.value.getSpanKind());
+    assertEquals(spanStartTime, kv.value.getStartTimeMillis());
+    assertEquals(spanEndTime, kv.value.getEndTimeMillis());
+
+    inputTopics.get(1).pipeInput(null, span1);
+    kv = outputTopic.readKeyValue();
+    assertNull(kv.key, "null key expected");
+    assertEquals("span-id-1", kv.value.getSpanId());
+    assertEquals("span-kind", kv.value.getSpanKind());
+    assertEquals(spanStartTime, kv.value.getStartTimeMillis());
+    assertEquals(spanEndTime, kv.value.getEndTimeMillis());
+
   }
 }

--- a/view-generator-framework/src/test/resources/configs/test-multi-view-generator/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-multi-view-generator/application.conf
@@ -1,0 +1,15 @@
+service.name = test-multi-view-generators
+service.admin.port = 8099
+
+main.class = org.hypertrace.core.viewgenerator.service.MultiViewGeneratorLauncher
+
+view.generators = ["test-view-gen-raw-service", "test-view-gen-span-event"]
+
+kafka.streams.config = {
+  application.id = test-multi-view-generators-job
+  metrics.recording.level = INFO
+  num.stream.threads = 1
+  bootstrap.servers = "localhost:9092"
+  schema.registry.url = "http://localhost:8081"
+}
+

--- a/view-generator-framework/src/test/resources/configs/test-multi-view-generator/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-multi-view-generator/application.conf
@@ -11,5 +11,7 @@ kafka.streams.config = {
   num.stream.threads = 1
   bootstrap.servers = "localhost:9092"
   schema.registry.url = "http://localhost:8081"
+  default.key.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
+  default.value.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
 }
 

--- a/view-generator-framework/src/test/resources/configs/test-view-gen-raw-service/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-gen-raw-service/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = ["test-input-topic1"]
+input.topics = ["test-input-topic1"]
 output.topic = "test-raw-service-type-output-topic"
 input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
 

--- a/view-generator-framework/src/test/resources/configs/test-view-gen-raw-service/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-gen-raw-service/application.conf
@@ -1,0 +1,26 @@
+service.name = test-view-genenartor
+service.admin.port = 8099
+
+main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
+
+input.topic = ["test-input-topic1"]
+output.topic = "test-raw-service-type-output-topic"
+input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
+
+kafka.streams.config = {
+  application.id = test-view-generation-job
+  metrics.recording.level = INFO
+  num.stream.threads = 1
+  bootstrap.servers = "localhost:9092"
+  schema.registry.url = "mock://localhost:8081"
+  default.key.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
+  default.value.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
+}
+
+view.generator.class = org.hypertrace.core.viewgenerator.TestRawServiceViewGenerator
+
+metrics.reporter {
+  prefix =  ai.traceable.platform.jobs.testViewGenRawServiceEvent
+  names = ["prometheus"]
+  console.reportInterval = 30
+}

--- a/view-generator-framework/src/test/resources/configs/test-view-gen-span-event/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-gen-span-event/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = ["test-input-topic1", "test-input-topic2"]
+input.topics = ["test-input-topic1", "test-input-topic2"]
 output.topic = "test-span-type-two-output-topic"
 input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
 

--- a/view-generator-framework/src/test/resources/configs/test-view-gen-span-event/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-gen-span-event/application.conf
@@ -1,0 +1,26 @@
+service.name = test-view-gen-span-event
+service.admin.port = 8099
+
+main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
+
+input.topic = ["test-input-topic1", "test-input-topic2"]
+output.topic = "test-span-type-two-output-topic"
+input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
+
+kafka.streams.config = {
+  application.id = test-view-generation-job
+  metrics.recording.level = INFO
+  num.stream.threads = 1
+  bootstrap.servers = "localhost:9092"
+  schema.registry.url = "mock://localhost:8081"
+  default.key.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
+  default.value.serde="org.hypertrace.core.kafkastreams.framework.serdes.AvroSerde"
+}
+
+view.generator.class = org.hypertrace.core.viewgenerator.TestSpanEventViewGenerator
+
+metrics.reporter {
+  prefix =  ai.traceable.platform.jobs.testViewGenSpanEvent
+  names = ["prometheus"]
+  console.reportInterval = 30
+}

--- a/view-generator-framework/src/test/resources/configs/test-view-generator/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-generator/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = ["test-input-topic1", "test-input-topic2"]
+input.topics = ["test-input-topic1", "test-input-topic2"]
 output.topic = "test-output-topic"
 input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
 

--- a/view-generator-framework/src/test/resources/configs/test-view-generator/application.conf
+++ b/view-generator-framework/src/test/resources/configs/test-view-generator/application.conf
@@ -3,7 +3,7 @@ service.admin.port = 8099
 
 main.class = org.hypertrace.core.viewgenerator.service.ViewGeneratorLauncher
 
-input.topic = "test-input-topic"
+input.topic = ["test-input-topic1", "test-input-topic2"]
 output.topic = "test-output-topic"
 input.class = org.hypertrace.core.viewgenerator.test.api.SpanTypeOne
 


### PR DESCRIPTION
## Description
There are cases where we need to costume from multiple topics for the same types of event. As part of this PR, we are extending `input.topic` from single to list.

As part of this PR, it also takes care of hard-coded string-based key serde to avro based (or as per stream configuration). 

### Testing
- Added test for ViewGenLauncher
- Added test for MultiViewLauncher

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Need to be part of the release note.
