### PR TITLE
fix: reverting back the pinot tools libs for compatibility issue

### DIFF
--- a/view-creator-framework/build.gradle.kts
+++ b/view-creator-framework/build.gradle.kts
@@ -21,8 +21,11 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2") {
       because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
     }
+    implementation("commons-collections:commons-collections:3.2.2") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078")
+    }
   }
-  implementation("org.apache.pinot:pinot-tools:0.10.0") {
+  implementation("org.apache.pinot:pinot-tools:0.7.1") {
     // All these third party libraries are not used in view creation workflow.
     // They bring in lot of vulnerabilities (snyk). so, excluding unused libs
     exclude("com.google.protobuf", "protobuf-java")

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
@@ -439,7 +439,7 @@ public class PinotUtils {
                 transformConfig.getString(PINOT_TRANSFORM_COLUMN_FUNCTION)));
       }
     }
-    return new IngestionConfig(null, null, null, tableTransformConfigs, null);
+    return new IngestionConfig(null, null, null, tableTransformConfigs);
   }
 
   private static TagOverrideConfig toTagOverrideConfig(Config tenantTagOverrideConfig) {
@@ -467,9 +467,7 @@ public class PinotUtils {
                 tierConfig.getString(PINOT_TIER_SEGMENT_SELECTOR_TYPE),
                 getOptionalString(tierConfig, PINOT_TIER_SEGMENT_AGE, null),
                 tierConfig.getString(PINOT_TIER_STORAGE_TYPE),
-                getOptionalString(tierConfig, PINOT_TIER_SERVER_TAG, null),
-                null,
-                null));
+                getOptionalString(tierConfig, PINOT_TIER_SERVER_TAG, null)));
       }
     }
     return tableTierConfigs;


### PR DESCRIPTION
The newer version of pinot-tools is not compatible with the existing schema we have. So, reverting back to 0.7.1 for now. Once we fix the schema, we will go back to latest version.

Error:
```
2023-02-24 06:24:35.311 [Thread-1] ERROR o.a.p.t.a.c.AddSchemaCommand - Got Exception to upload Pinot Schema: backendEntityView
org.apache.pinot.common.exception.HttpErrorStatusException: Got error status code: 400 (Bad Request) with reason: "New schema: backendEntityView is not backward-compatible with the existing schema" while sending request: http://pinot-controller:9000/schemas to controller: pinot-controller-0.pinot-controller.traceable.svc.cluster.local, version: Unknown
	at org.apache.pinot.common.utils.FileUploadDownloadClient.sendRequest(FileUploadDownloadClient.java:539) ~[pinot-common-0.10.0.jar:0.10.0-30c4635bfeee88f88aa9c9f63b93bcd4a650607f]
	at org.apache.pinot.common.utils.FileUploadDownloadClient.addSchema(FileUploadDownloadClient.java:664) ~[pinot-common-0.10.0.jar:0.10.0-30c4635bfeee88f88aa9c9f63b93bcd4a650607f]
	at org.apache.pinot.tools.admin.command.AddSchemaCommand.execute(AddSchemaCommand.java:152) ~[pinot-tools-0.10.0.jar:0.10.0-30c4635bfeee88f88aa9c9f63b93bcd4a650607f]
	at org.hypertrace.core.viewcreator.pinot.PinotUtils.uploadPinotSchema(PinotUtils.java:166) ~[view-creator-framework-0.4.10.jar:?]
	at org.hypertrace.core.viewcreator.pinot.PinotUtils.uploadPinotSchema(PinotUtils.java:145) ~[view-creator-framework-0.4.10.jar:?]
	at org.hypertrace.core.viewcreator.pinot.PinotTableCreationTool.create(PinotTableCreationTool.java:34) ~[view-creator-framework-0.4.10.jar:?]
	at org.hypertrace.core.viewcreator.ViewCreatorLauncher.doStart(ViewCreatorLauncher.java:30) ~[view-creator-framework-0.4.10.jar:?]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
2023-02-24 06:24:35.318 [Thread-1] ERROR o.h.c.v.ViewCreatorLauncher - Error in doStart
java.lang.RuntimeException: Failed to upload pinot schema: backendEntityView
	at org.hypertrace.core.viewcreator.pinot.PinotTableCreationTool.create(PinotTableCreationTool.java:37) ~[view-creator-framework-0.4.10.jar:?]
	at org.hypertrace.core.viewcreator.ViewCreatorLauncher.doStart(ViewCreatorLauncher.java:30) ~[view-creator-framework-0.4.10.jar:?]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
```