### PR TITLE
add support for creating fieldConfigs for text index columns

### DIFF
--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
@@ -68,4 +68,7 @@ public class PinotTableSpec {
 
   // routing configs
   @Optional private Config routingConfig;
+
+  // Field configs
+  @Optional private List<String> textIndexColumns;
 }

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
@@ -55,6 +55,9 @@ import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -346,6 +349,8 @@ public class PinotUtils {
             .setTagOverrideConfig(toTagOverrideConfig(pinotTableSpec.getTagOverrideConfigs()))
             // Tier configs
             .setTierConfigList(getTableTierConfigs(pinotTableSpec))
+            // Field configs
+            .setFieldConfigList(toFieldConfigs(pinotTableSpec))
             // Task configurations
             .setTaskConfig(toTableTaskConfig(pinotTableSpec.getTaskConfigs()))
             // ingestion configurations
@@ -480,6 +485,16 @@ public class PinotUtils {
       }
     }
     return tableTierConfigs;
+  }
+
+  private static List<FieldConfig> toFieldConfigs(@Nullable PinotTableSpec tableSpec) {
+    if (tableSpec == null || tableSpec.getTextIndexColumns() == null) {
+      return null;
+    }
+
+    return tableSpec.getTextIndexColumns().stream()
+        .map(columnName -> new FieldConfig(columnName, EncodingType.RAW, IndexType.TEXT, null))
+        .collect(Collectors.toUnmodifiableList());
   }
 
   private static TableTaskConfig toTableTaskConfig(@Nullable Config allTasksConfigs) {

--- a/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
+++ b/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
@@ -88,6 +88,8 @@ public class ViewCreationSpecTest {
     Config filterConfig = pinotTableSpec.getFilterConfig();
     assertEquals(
         filterConfig.getString(PINOT_FILTER_FUNCTION), "strcmp(customer_id, 'abcd-1234') != 0");
+
+    assertEquals(pinotTableSpec.getTextIndexColumns(), List.of("response_body"));
   }
 
   @Test

--- a/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/pinot/PinotUtilsTest.java
+++ b/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/pinot/PinotUtilsTest.java
@@ -10,6 +10,7 @@ import static org.hypertrace.core.viewcreator.pinot.PinotUtils.getPinotOfflineTa
 import static org.hypertrace.core.viewcreator.pinot.PinotUtils.getPinotRealtimeTableSpec;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.typesafe.config.ConfigFactory;
@@ -18,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -228,6 +232,15 @@ public class PinotUtilsTest {
     FilterConfig filterConfig =
         requireNonNull(requireNonNull(tableConfig.getIngestionConfig()).getFilterConfig());
     assertEquals("strcmp(customer_id, 'abcd-1234') != 0", filterConfig.getFilterFunction());
+
+    // verify field configs
+    List<FieldConfig> fieldConfigs = requireNonNull(tableConfig.getFieldConfigList());
+    assertEquals(1, fieldConfigs.size());
+    FieldConfig fieldConfig = fieldConfigs.get(0);
+    assertEquals("response_body", fieldConfig.getName());
+    assertEquals(EncodingType.RAW, fieldConfig.getEncodingType());
+    assertEquals(IndexType.TEXT, fieldConfig.getIndexType());
+    assertNull(fieldConfig.getProperties());
   }
 
   @Test

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
@@ -21,6 +21,7 @@ pinot = {
   noDictionaryColumns = [properties__VALUES]
   bloomFilterColumns = [id_sha]
   rangeIndexColumns = [creation_time_millis, start_time_millis]
+  textIndexColumns = [response_body]
   tableName = myView1
   loadMode = MMAP
   numReplicas = 2


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
