### PR TITLE
feat: add supports for exposing completion config, and skip prior segements

### DIFF
--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
@@ -70,5 +70,8 @@ public class PinotTableSpec {
   @Optional private Config routingConfig;
 
   // Field configs
-  @Optional private List<String> textIndexColumns;
+  @Optional private List<Config> textIndexConfigs;
+
+  // Completion Config for realtime table config
+  @Optional private Config completionConfig;
 }

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotTableSpec.java
@@ -70,7 +70,7 @@ public class PinotTableSpec {
   @Optional private Config routingConfig;
 
   // Field configs
-  @Optional private List<Config> textIndexConfigs;
+  @Optional private List<Config> fieldConfigs;
 
   // Completion Config for realtime table config
   @Optional private Config completionConfig;

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotUtils.java
@@ -361,7 +361,6 @@ public class PinotUtils {
             .setRoutingConfig(toRoutingConfig(pinotTableSpec.getRoutingConfig()))
             // setCompletionConfig
             .setCompletionConfig(toCompletionConfig(pinotTableSpec));
-    // setCompletionConfig
 
     if (tableType == TableType.REALTIME) {
       // Stream configs only for REALTIME

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotViewCreatorConfig.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotViewCreatorConfig.java
@@ -58,10 +58,6 @@ public class PinotViewCreatorConfig {
   /////////////
   public static final String PINOT_REST_URI_TABLES = "tables";
 
-  // text index config keys
-  public static final String TEXT_INDEX_CONFIG_COLUMN = "column";
-  public static final String TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS = "skipPriorSegments";
-
   // completion config keys
   public static final String COMPLETION_CONFIG_COMPLETION_MODE = "completionMode";
 }

--- a/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotViewCreatorConfig.java
+++ b/view-creator-framework/src/main/java/org/hypertrace/core/viewcreator/pinot/PinotViewCreatorConfig.java
@@ -57,4 +57,11 @@ public class PinotViewCreatorConfig {
   // REST API
   /////////////
   public static final String PINOT_REST_URI_TABLES = "tables";
+
+  // text index config keys
+  public static final String TEXT_INDEX_CONFIG_COLUMN = "column";
+  public static final String TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS = "skipPriorSegments";
+
+  // completion config keys
+  public static final String COMPLETION_CONFIG_COMPLETION_MODE = "completionMode";
 }

--- a/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
+++ b/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
@@ -3,8 +3,6 @@ package org.hypertrace.core.viewcreator;
 import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.COMPLETION_CONFIG_COMPLETION_MODE;
 import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.PINOT_FILTER_FUNCTION;
 import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.PINOT_TRANSFORM_COLUMN_NAME;
-import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.TEXT_INDEX_CONFIG_COLUMN;
-import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -92,9 +90,9 @@ public class ViewCreationSpecTest {
     assertEquals(
         filterConfig.getString(PINOT_FILTER_FUNCTION), "strcmp(customer_id, 'abcd-1234') != 0");
 
-    Config textIndexConfig = pinotTableSpec.getTextIndexConfigs().get(0);
-    assertEquals(textIndexConfig.getString(TEXT_INDEX_CONFIG_COLUMN), "response_body");
-    assertEquals(textIndexConfig.getBoolean(TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS), true);
+    Config fieldConfig = pinotTableSpec.getFieldConfigs().get(0);
+    assertEquals(fieldConfig.getString("name"), "response_body");
+    assertEquals(fieldConfig.getBoolean("properties.skipExistingSegments"), true);
 
     Config completionConfig = pinotTableSpec.getCompletionConfig();
     assertEquals(completionConfig.getString(COMPLETION_CONFIG_COMPLETION_MODE), "DOWNLOAD");

--- a/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
+++ b/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/ViewCreationSpecTest.java
@@ -1,7 +1,10 @@
 package org.hypertrace.core.viewcreator;
 
+import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.COMPLETION_CONFIG_COMPLETION_MODE;
 import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.PINOT_FILTER_FUNCTION;
 import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.PINOT_TRANSFORM_COLUMN_NAME;
+import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.TEXT_INDEX_CONFIG_COLUMN;
+import static org.hypertrace.core.viewcreator.pinot.PinotViewCreatorConfig.TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -89,7 +92,12 @@ public class ViewCreationSpecTest {
     assertEquals(
         filterConfig.getString(PINOT_FILTER_FUNCTION), "strcmp(customer_id, 'abcd-1234') != 0");
 
-    assertEquals(pinotTableSpec.getTextIndexColumns(), List.of("response_body"));
+    Config textIndexConfig = pinotTableSpec.getTextIndexConfigs().get(0);
+    assertEquals(textIndexConfig.getString(TEXT_INDEX_CONFIG_COLUMN), "response_body");
+    assertEquals(textIndexConfig.getBoolean(TEXT_INDEX_CONFIG_SKIP_PRIOR_SEGMENTS), true);
+
+    Config completionConfig = pinotTableSpec.getCompletionConfig();
+    assertEquals(completionConfig.getString(COMPLETION_CONFIG_COMPLETION_MODE), "DOWNLOAD");
   }
 
   @Test

--- a/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/pinot/PinotUtilsTest.java
+++ b/view-creator-framework/src/test/java/org/hypertrace/core/viewcreator/pinot/PinotUtilsTest.java
@@ -10,7 +10,7 @@ import static org.hypertrace.core.viewcreator.pinot.PinotUtils.getPinotOfflineTa
 import static org.hypertrace.core.viewcreator.pinot.PinotUtils.getPinotRealtimeTableSpec;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.typesafe.config.ConfigFactory;
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
 import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
@@ -240,7 +241,13 @@ public class PinotUtilsTest {
     assertEquals("response_body", fieldConfig.getName());
     assertEquals(EncodingType.RAW, fieldConfig.getEncodingType());
     assertEquals(IndexType.TEXT, fieldConfig.getIndexType());
-    assertNull(fieldConfig.getProperties());
+    assertEquals(fieldConfig.getProperties().get("fstType"), "lucene");
+    assertEquals(fieldConfig.getProperties().get("skipExistingSegments"), "true");
+
+    // verify completion configs
+    CompletionConfig completionConfig = tableConfig.getValidationConfig().getCompletionConfig();
+    assertNotNull(completionConfig);
+    assertEquals(completionConfig.getCompletionMode(), "DOWNLOAD");
   }
 
   @Test

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
@@ -21,7 +21,11 @@ pinot = {
   noDictionaryColumns = [properties__VALUES]
   bloomFilterColumns = [id_sha]
   rangeIndexColumns = [creation_time_millis, start_time_millis]
-  textIndexColumns = [response_body]
+  textIndexConfigs = [{
+    column = response_body
+    skipPriorSegments = true
+  }]
+  noTextIndexOnPreviousSegments = true
   tableName = myView1
   loadMode = MMAP
   numReplicas = 2
@@ -104,6 +108,10 @@ pinotRealtime = {
   routingConfig = {
     instanceSelectorType = "replicaGroup"
     segmentPrunerTypes =  ["time", "partition"]
+  }
+
+  completionConfig = {
+    completionMode = "DOWNLOAD"
   }
 }
 

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
@@ -21,7 +21,6 @@ pinot = {
   noDictionaryColumns = [properties__VALUES]
   bloomFilterColumns = [id_sha]
   rangeIndexColumns = [creation_time_millis, start_time_millis]
-  noTextIndexOnPreviousSegments = true
   tableName = myView1
   loadMode = MMAP
   numReplicas = 2

--- a/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
+++ b/view-creator-framework/src/test/resources/sample-view-generation-spec.conf
@@ -21,10 +21,6 @@ pinot = {
   noDictionaryColumns = [properties__VALUES]
   bloomFilterColumns = [id_sha]
   rangeIndexColumns = [creation_time_millis, start_time_millis]
-  textIndexConfigs = [{
-    column = response_body
-    skipPriorSegments = true
-  }]
   noTextIndexOnPreviousSegments = true
   tableName = myView1
   loadMode = MMAP
@@ -35,6 +31,14 @@ pinot = {
   serverTenant = defaultServer
   segmentAssignmentStrategy = BalanceNumSegmentAssignmentStrategy
   peerSegmentDownloadScheme = http
+
+  fieldConfigs = [{
+    name = response_body
+    properties = {
+      fstType = "lucene"
+      skipExistingSegments = "true"
+    }
+  }]
 }
 
 pinotRealtime = {


### PR DESCRIPTION
## Description
Add support for adding completion config, and supports for skip building indexes for previous segments

Ref: https://docs.pinot.apache.org/configuration-reference/table#field-config-list



### Testing
Added Unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


